### PR TITLE
(Github Notifications Dropdown) Compatibility fix for Greasemonkey 4.0

### DIFF
--- a/other/gm_scripts/github_notifications_dropdown/github_notifications_dropdown.user.js
+++ b/other/gm_scripts/github_notifications_dropdown/github_notifications_dropdown.user.js
@@ -45,7 +45,7 @@ function onNotificationButtonClicked(evt){
 	}
 	evt.preventDefault();
 	notificationButtonContainer.off("click", onNotificationButtonClicked);
-	var targetPage = notificationButtonLink.attr('href');
+	var targetPage = notificationButtonLink.get(0).href;
 	fetchNotifications(targetPage);
 }
 

--- a/other/gm_scripts/github_notifications_dropdown/github_notifications_dropdown.user.js
+++ b/other/gm_scripts/github_notifications_dropdown/github_notifications_dropdown.user.js
@@ -2,7 +2,7 @@
 // @name           Github Notifications Dropdown
 // @namespace      joeytwiddle
 // @copyright      2014-2017, Paul "Joey" Clark (http://neuralyte.org/~joey)
-// @version        1.1.0
+// @version        1.1.1
 // @description    When clicking the notifications icon, displays notifications in a dropdown pane, without leaving the current page.
 // @include        https://github.com/*
 // @require        https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js
@@ -14,7 +14,7 @@
 // When using @grant none then we should also avoid messing with the page's jQuery (or lack of jQuery).
 this.$ = this.jQuery = jQuery.noConflict(true);
 
-// Contributors: joeytwiddle, SkyzohKeyx, Marti
+// Contributors: joeytwiddle, SkyzohKeyx, Marti, darkred
 
 // ==Options==
 

--- a/other/gm_scripts/github_notifications_dropdown/github_notifications_dropdown.user.js
+++ b/other/gm_scripts/github_notifications_dropdown/github_notifications_dropdown.user.js
@@ -45,7 +45,8 @@ function onNotificationButtonClicked(evt){
 	}
 	evt.preventDefault();
 	notificationButtonContainer.off("click", onNotificationButtonClicked);
-	var targetPage = notificationButtonLink.get(0).href;
+	// For GM 4.0 we must use an absolute path, so we use .prop() instead of .attr().  "This is an issue with Firefox and content scripts"
+	var targetPage = notificationButtonLink.prop("href");
 	fetchNotifications(targetPage);
 }
 


### PR DESCRIPTION
Hi there.

This is compatibility fix for Greasemonkey 4.0 :
> _Use absolute paths. This is an issue with Firefox and content scripts._

(https://github.com/greasemonkey/greasemonkey/issues/2680#issuecomment-344778286)